### PR TITLE
Bump the sidekiq version to the latest

### DIFF
--- a/sidekiq_status.gemspec
+++ b/sidekiq_status.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SidekiqStatus::VERSION
 
-  gem.add_runtime_dependency("sidekiq", ">= 2.4", "<= 2.12")
+  gem.add_runtime_dependency("sidekiq", ">= 2.4", "<= 2.14")
 
   gem.add_development_dependency("activesupport")
   gem.add_development_dependency("rspec")


### PR DESCRIPTION
To 2.14. I actually ended up using version 2.12.1 (instead of 2.12.0), so I haven't tested against the latest.

However, 2.14 is the latest sidekiq that is out, and this gem can't be bundled with it without this version bump.
