### PR TITLE
Do not start reporting status when job is scheduled for the future

### DIFF
--- a/lib/sidekiq_status/client_middleware.rb
+++ b/lib/sidekiq_status/client_middleware.rb
@@ -6,6 +6,9 @@ module SidekiqStatus
       worker = worker.constantize if worker.is_a?(String)
       return yield unless worker < SidekiqStatus::Worker
 
+      # Don't start reporting status if the job is scheduled for the future
+      return yield if item['at']
+
       jid  = item['jid']
       args = item['args']
       item['args'] = [jid]

--- a/spec/client_middleware_spec.rb
+++ b/spec/client_middleware_spec.rb
@@ -19,4 +19,11 @@ describe SidekiqStatus::ClientMiddleware do
       end
     end
   end
+
+  it "does not create container for scheduled job" do
+    SidekiqStatus::Container.should_not_receive(:create)
+
+    subject.call("TestWorker1", { "at" => Time.now }, nil) do
+    end
+  end
 end


### PR DESCRIPTION
When a job is scheduled far beyond in future the status gem starts reporting the status right away. I think it should start reporting only when the job actually runs.

This patch makes it happen.
