### PR TITLE
Use Sidekiq::Worker#jid instead of replacing job arguments with jid  generated by SidekiqStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ and clean status containers.
 ### 1.1.0
 
   * Support for sidekiq 4.1, 4.0, 3.5, 3.4
+  * No more replacement of original job arguments with generated unique jid. 
+    This is not needed anymore as Sidekiq started to do it. 
+    This change should make integration with other middlewares easier.
   * Dropped support for sidekiq versions older than 3.3
   * Dropped support for ruby 1.9.x, 2.0.x
   * Experimental support for Rubinius

--- a/lib/sidekiq_status/client_middleware.rb
+++ b/lib/sidekiq_status/client_middleware.rb
@@ -23,7 +23,6 @@ module SidekiqStatus
 
       jid  = item['jid']
       args = item['args']
-      item['args'] = [jid]
 
       SidekiqStatus::Container.create(
           'jid'    => jid,

--- a/lib/sidekiq_status/container.rb
+++ b/lib/sidekiq_status/container.rb
@@ -156,7 +156,7 @@ module SidekiqStatus
     # @param [Array<#to_s>] jids a list of job identifiers to load data for
     # @return [Hash{String => Hash}] A hash of job-id to deserialized data pairs
     def self.load_data_multi(jids)
-      keys = jids.map { |jid| status_key(jid) }
+      keys = jids.map(&method(:status_key))
 
       return {} if keys.empty?
 

--- a/lib/sidekiq_status/worker.rb
+++ b/lib/sidekiq_status/worker.rb
@@ -14,13 +14,13 @@ module SidekiqStatus
     end
 
     module Prepending
-      def perform(jid)
+      def perform(*args)
         @status_container = SidekiqStatus::Container.load(jid)
 
         begin
           catch(:killed) do
             set_status('working')
-            super(*@status_container.args)
+            super(*args)
             set_status('complete')
           end
         rescue Exception => exc


### PR DESCRIPTION
When SidekiqStatus was developed, sidekiq did not support the notion of
jid - so the result value of Sidekiq::Worker.perform_async was a
truthy/falsey value, not a unique jid.

Because of that SidekiqStatus had to introduce that and massage job
arguments back and forth.

Nowadays, sidekiq generates jid for each individual job on its own and
Sidekiq::Processor ensures that Sidekiq::Worker#jid attr_reader is assigned
to the jid of the currently processing job.

Because of that, there is no need for SidekiqStatus to do this
arguments massaging anymore.

This commit removes this argument massaging and relies of
Sidekiq::Processor to setup Sidekiq::Worker#j anymore.

This commit removes this argument massaging and relies of
Sidekiq::Processor to setup Sidekiq::Worker#jid

Hopefully this change should simplify the code need to make
SidekiqStatus work together with retry jobs middleware and
sidekiq_unique_jobs (pending)