### PR TITLE
Adds support for Sidekiq 4.2+

### DIFF
--- a/lib/sidekiq_status/version.rb
+++ b/lib/sidekiq_status/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
 module SidekiqStatus
   # SidekiqStatus version
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/sidekiq_status.gemspec
+++ b/sidekiq_status.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SidekiqStatus::VERSION
 
-  gem.add_runtime_dependency("sidekiq", ">= 3.3", "< 4.2")
+  gem.add_runtime_dependency("sidekiq", ">= 3.3", "< 5")
 
   gem.add_development_dependency("activesupport")
   gem.add_development_dependency("rspec", '>= 3.4.0')

--- a/web/views/status.erb
+++ b/web/views/status.erb
@@ -60,6 +60,6 @@
         </tr>
       </tbody>
     </table>
-    <a href="<%= to(:statuses) %>">Back</a>
+    <a href="<%= root_path %>statuses">Back</a>
   </div>
 </div>

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -2,15 +2,15 @@
 
 <div class="delete_jobs">
   Delete jobs in&nbsp;
-  <a href="<%= to(:statuses) %>/delete/complete" onclick="return confirm('Are you sure? Delete is irreversible')">
+  <a href="<%= root_path %>statuses/delete/complete" onclick="return confirm('Are you sure? Delete is irreversible')">
     complete
   </a>
   ,&nbsp;
-  <a href="<%= to(:statuses) %>/delete/finished" onclick="return confirm('Are you sure? Delete is irreversible')" title="<%= SidekiqStatus::Container::FINISHED_STATUS_NAMES.join(', ') %>">
+  <a href="<%= root_path %>statuses/delete/finished" onclick="return confirm('Are you sure? Delete is irreversible')" title="<%= SidekiqStatus::Container::FINISHED_STATUS_NAMES.join(', ') %>">
     finished
   </a>
   ,&nbsp;
-  <a href="<%= to(:statuses) %>/delete/all"      onclick="return confirm('Are you sure? Delete is irreversible')">
+  <a href="<%= root_path %>statuses/delete/all"      onclick="return confirm('Are you sure? Delete is irreversible')">
     all
   </a>
   &nbsp;statuses
@@ -28,7 +28,7 @@
   <% @statuses.each do |container| %>
     <tr>
       <td>
-        <a href="<%= to(:statuses) %>/<%= container.jid %>">
+        <a href="<%= root_path %>/statuses/<%= container.jid %>">
           <%= container.worker %>
           <br />
           <%= container.jid %>
@@ -45,7 +45,7 @@
       <td><%= container.message %></td>
       <td>
         <% if container.killable? %>
-          <a class="kill" href="<%= to(:statuses) %>/<%= container.jid %>/kill" onclick="return confirm('Are you sure?')">Kill</a>
+          <a class="kill" href="<%= root_path %>statuses/<%= container.jid %>/kill" onclick="return confirm('Are you sure?')">Kill</a>
         <% elsif container.kill_requested? %>
           Kill requested
         <% end %>


### PR DESCRIPTION
This Pull Request adds support for Sidekiq version 4.2 and up, by removing calls to Sinatra's `to` method and replacing them with the new way to go, as seen on Sidekiq's templates (using `root_path`).

This allows for using this great gem with the new `Sidekiq::Web`, which does not depend on Sinatra anymore.