### PR TITLE
Fix redirect issues in Sidekiq 4.2+

### DIFF
--- a/lib/sidekiq_status/web.rb
+++ b/lib/sidekiq_status/web.rb
@@ -11,6 +11,16 @@ module SidekiqStatus
           path = File.join(VIEW_PATH, name.to_s) + ".erb"
           File.open(path).read
         end
+
+        def redirect_to(subpath)
+          if respond_to?(:to)
+            # Sinatra-based web UI
+            redirect to(subpath)
+          else
+            # Non-Sinatra based web UI (Sidekiq 4.2+)
+            "#{root_path}#{subpath}"
+          end
+        end
       end
 
       app.get '/statuses' do
@@ -34,22 +44,22 @@ module SidekiqStatus
 
       app.get '/statuses/:jid/kill' do
         SidekiqStatus::Container.load(params[:jid]).request_kill
-        redirect to(:statuses)
+        redirect_to :statuses
       end
 
       app.get '/statuses/delete/all' do
         SidekiqStatus::Container.delete
-        redirect to(:statuses)
+        redirect_to :statuses
       end
 
       app.get '/statuses/delete/complete' do
         SidekiqStatus::Container.delete('complete')
-        redirect to(:statuses)
+        redirect_to :statuses
       end
 
       app.get '/statuses/delete/finished' do
         SidekiqStatus::Container.delete(SidekiqStatus::Container::FINISHED_STATUS_NAMES)
-        redirect to(:statuses)
+        redirect_to :statuses
       end
     end
   end

--- a/lib/sidekiq_status/web.rb
+++ b/lib/sidekiq_status/web.rb
@@ -18,7 +18,7 @@ module SidekiqStatus
             redirect to(subpath)
           else
             # Non-Sinatra based web UI (Sidekiq 4.2+)
-            "#{root_path}#{subpath}"
+            redirect "#{root_path}#{subpath}"
           end
         end
       end


### PR DESCRIPTION
This makes conditional the use of Sinatra's `#to` method in the controllers of the Web UI, as this method is not present in the new, non-Sinatra-based web UI. Depending on the presence of that method, this gem's controllers will make redirects using *the Sinatra way* or the (uglier) *string-concatenating way*.