### PR TITLE
Update sidekiq dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
     - SHOW_SIDEKIQ=true
   matrix:
+    - SIDEKIQ_VERSION="~>5.0.3"
     - SIDEKIQ_VERSION="~>4.2.0"
     - SIDEKIQ_VERSION="~>4.1.0"
     - SIDEKIQ_VERSION="~>4.0.2"

--- a/lib/sidekiq_status/container.rb
+++ b/lib/sidekiq_status/container.rb
@@ -1,4 +1,5 @@
 # -*- encoding : utf-8 -*-
+require 'active_support/core_ext/class'
 
 # Sidekiq extension to track job execution statuses and returning job results back to the client in a convenient manner
 module SidekiqStatus

--- a/sidekiq_status.gemspec
+++ b/sidekiq_status.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SidekiqStatus::VERSION
 
+  gem.add_runtime_dependency("activesupport")
   gem.add_runtime_dependency("sidekiq", ">= 3.3", "< 6")
 
-  gem.add_development_dependency("activesupport")
   gem.add_development_dependency("rspec", '>= 3.4.0')
   gem.add_development_dependency("rspec-its")
   gem.add_development_dependency("simplecov")

--- a/sidekiq_status.gemspec
+++ b/sidekiq_status.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SidekiqStatus::VERSION
 
-  gem.add_runtime_dependency("sidekiq", ">= 3.3", "< 5")
+  gem.add_runtime_dependency("sidekiq", ">= 3.3", "< 6")
 
   gem.add_development_dependency("activesupport")
   gem.add_development_dependency("rspec", '>= 3.4.0')


### PR DESCRIPTION
to allow sidekiq 5.

I'm using both sidekiq-status and sidekiq, and I would like to upgrade this gem to accept sidekiq 5 as well. 

It seems that the container class uses `class_attribute` method that is provided by activesupport. So I added a require for that as well.